### PR TITLE
Fix 2 team page focus bugs

### DIFF
--- a/reddit_about/public/static/js/about/about-team.js
+++ b/reddit_about/public/static/js/about/about-team.js
@@ -186,7 +186,9 @@ PersonDetailsPopup = Backbone.View.extend({
 
     show: function(view) {
         var oldModel = this.model
-        this.hide(true)
+        if (this.targetView) {
+            this.targetView.$el.removeClass('focused')
+        }
         this.targetView = view
         this.model = view.model
 
@@ -198,15 +200,13 @@ PersonDetailsPopup = Backbone.View.extend({
         this.trigger('show', this.model, oldModel)
     },
 
-    hide: function(isChange) {
+    hide: function() {
         var oldModel = this.model
         this.model = null
         if (this.targetView) {
             this.targetView.$el.removeClass('focused')
             this.targetView = null
-            if (!isChange) {
-                this.trigger('hide', oldModel)
-            }
+            this.trigger('hide', oldModel)
         }
         this.$el.hide()
     },

--- a/reddit_about/public/static/js/about/about-team.js
+++ b/reddit_about/public/static/js/about/about-team.js
@@ -185,6 +185,7 @@ PersonDetailsPopup = Backbone.View.extend({
     },
 
     show: function(view) {
+        var oldModel = this.model
         this.hide(true)
         this.targetView = view
         this.model = view.model
@@ -194,7 +195,7 @@ PersonDetailsPopup = Backbone.View.extend({
         this.$el.show()
 
         this.targetView.$el.addClass('focused')
-        this.trigger('show', this.model)
+        this.trigger('show', this.model, oldModel)
     },
 
     hide: function(isChange) {
@@ -262,9 +263,13 @@ PeopleGridView = GridView.extend({
         return view
     },
 
-    focus: function(model) {
+    focus: function(model, oldModel) {
+        var $content = $('.content')
         this.$el.addClass('focusing')
-        $('.content').addClass('focusing-' + model.id)
+        if (oldModel) {
+            $content.removeClass('focusing-' + oldModel.id)
+        }
+        $content.addClass('focusing-' + model.id)
     },
 
     unfocus: function(model) {


### PR DESCRIPTION
Fun with events!
- If a team member was focused and then focus changed to another member without closing the bubble, a `'hide'` event never fired, causing the `#about-team` element to pile up `.focusing-username` classes. You can see this by clicking kn0thing and then another avatar on the site -- the bubble corners will stay rounded.
- Clicking the 'x' close button on the details popup would trigger the `hide` function, but since it was a delegated event, it also passed an event object that was unintentionally making `isChange` truthy, causing a `'hide'` event to not fire. This meant that clicking the 'x' won't properly set the UI to the non-faded unfocused state. This is especially bad when alienth is focused, because it traps you in the darkened state and prevents from selecting any other avatars until you click on alienth again.
