### PR TITLE
advertising: Fix display of cpm in platform blurb.

### DIFF
--- a/reddit_about/pages.py
+++ b/reddit_about/pages.py
@@ -99,10 +99,10 @@ class Advertising(Templated):
         blurbs = SelfServeBlurb.get_all(return_dict=True)
         if 'platform' in blurbs:
             min_cpm = min([
-                g.cpm_selfserve_collection,
-                g.cpm_selfserve,
-                g.cpm_selfserve_geotarget_metro,
-            ]).decimal
+                g.cpm_selfserve_collection.decimal,
+                g.cpm_selfserve.decimal,
+                g.cpm_selfserve_geotarget_metro.decimal,
+            ])
             formatted_min_cpm = format_currency(min_cpm, 'USD', locale=c.locale)
             formatted_min_bid = format_currency(g.min_promote_bid, 'USD', locale=c.locale)
             blurbs['platform'].text = blurbs['platform'].text.replace(


### PR DESCRIPTION
Turns out calling 'min' on these doesn't work. I'm not really sure what it's doing. Casting them to decimals first does the trick, though.  I'm 95% sure I checked this before pushing it out, but maybe I'm just crazy.

:eyeglasses: @bsimpson63 
