### PR TITLE
advertising: Make contact link in header point to typeform form.

### DIFF
--- a/reddit_about/__init__.py
+++ b/reddit_about/__init__.py
@@ -37,7 +37,11 @@ class About(Plugin):
             'about-team.js',
             'about-postcards.js',
             prefix='about/',
-        )
+        ),
+        'advertising': Module('advertising.js',
+            'advertising.js',
+            prefix='advertising/',
+        ),
     }
 
     def add_routes(self, mc):

--- a/reddit_about/public/static/js/advertising/advertising.js
+++ b/reddit_about/public/static/js/advertising/advertising.js
@@ -6,11 +6,19 @@
     // added to the link section in the footer (which is markdown pulled from
     // a wiki page), I'm just going to attach events to all of the links on the
     // page containing 'redditadvertising' in the href since it works for both
-    $('a[href*=redditadvertising]').on('click', function() {
+    $('a[href*=redditadvertising]').on('click', function(e) {
+      e.stopPropagation();
       // get the name of the nearest parent element with a selfserve-* css class
       // so the sales team can tell which instance of the link it is
+      var redirectURL = this.href;
       var parentClass = $(this).closest('[class^=selfserve]').attr('class');
-      r.analytics.fireGAEvent('advertising', 'contactLinkClicked', parentClass, this.href);
+      r.analytics.fireFunnelEvent(
+        'advertising',
+        'contactLinkClicked',
+        { label: parentClass },
+        function() {
+          window.location.href = redirectURL;
+        });
     });
   });
 }(r, jQuery);

--- a/reddit_about/public/static/js/advertising/advertising.js
+++ b/reddit_about/public/static/js/advertising/advertising.js
@@ -1,0 +1,16 @@
+!function(r, $) {
+  'use strict';
+  
+  $(function() {
+    // ugh. since this link is going to be hardcoded into the template _and_
+    // added to the link section in the footer (which is markdown pulled from
+    // a wiki page), I'm just going to attach events to all of the links on the
+    // page containing 'redditadvertising' in the href since it works for both
+    $('a[href*=redditadvertising]').on('click', function() {
+      // get the name of the nearest parent element with a selfserve-* css class
+      // so the sales team can tell which instance of the link it is
+      var parentClass = $(this).parents('[class^=selfserve]').eq(0).attr('class');
+      r.analytics.fireGAEvent('advertising', 'contactLinkClicked', parentClass, this.href);
+    });
+  });
+}(r, jQuery);

--- a/reddit_about/public/static/js/advertising/advertising.js
+++ b/reddit_about/public/static/js/advertising/advertising.js
@@ -9,7 +9,7 @@
     $('a[href*=redditadvertising]').on('click', function() {
       // get the name of the nearest parent element with a selfserve-* css class
       // so the sales team can tell which instance of the link it is
-      var parentClass = $(this).parents('[class^=selfserve]').eq(0).attr('class');
+      var parentClass = $(this).closest('[class^=selfserve]').attr('class');
       r.analytics.fireGAEvent('advertising', 'contactLinkClicked', parentClass, this.href);
     });
   });

--- a/reddit_about/templates/advertising.html
+++ b/reddit_about/templates/advertising.html
@@ -54,7 +54,7 @@ from r2.lib.filters import safemarkdown
             <div class="col-4">
               <a href="${thing.create_ad_url}" class="create-ad-button primary-button button">${_("create an ad")}</a>
               <small>${_("budget larger than $30k?")}<br>
-              <a href="http://bit.ly/redditadvertising">${_("contact our sales team")}</a></small>
+              <a href="https://redditadvertising.typeform.com/to/OiZLa5">${_("contact our sales team")}</a></small>
             </div>
           </div>
         </div>

--- a/reddit_about/templates/advertising.html
+++ b/reddit_about/templates/advertising.html
@@ -54,7 +54,7 @@ from r2.lib.filters import safemarkdown
             <div class="col-4">
               <a href="${thing.create_ad_url}" class="create-ad-button primary-button button">${_("create an ad")}</a>
               <small>${_("budget larger than $30k?")}<br>
-              <a href="mailto:advertising@reddit.com?subject=campaign%20inquiry">${_("contact our sales team")}</a></small>
+              <a href="http://bit.ly/redditadvertising">${_("contact our sales team")}</a></small>
             </div>
           </div>
         </div>

--- a/reddit_about/templates/advertisingpage.html
+++ b/reddit_about/templates/advertisingpage.html
@@ -5,3 +5,9 @@
   ${parent.stylesheet()}
   ${less_stylesheet('selfserve.less')}
 </%def>
+
+<%def name="javascript_bottom()">
+  ${parent.javascript_bottom()}
+  <% from r2.lib import js %>
+  ${unsafe(js.use('advertising'))}
+</%def>


### PR DESCRIPTION
From ryan:

> madlee: can we switch out the managed email link on /advertising to http://bit.ly/redditadvertising ?

the answer is yes, ryan.

:eyeglasses: @dwick
