### PR TITLE
Switch managed email link

### DIFF
--- a/reddit_about/__init__.py
+++ b/reddit_about/__init__.py
@@ -37,7 +37,11 @@ class About(Plugin):
             'about-team.js',
             'about-postcards.js',
             prefix='about/',
-        )
+        ),
+        'advertising': Module('advertising.js',
+            'advertising.js',
+            prefix='advertising/',
+        ),
     }
 
     def add_routes(self, mc):

--- a/reddit_about/public/static/js/advertising/advertising.js
+++ b/reddit_about/public/static/js/advertising/advertising.js
@@ -1,0 +1,35 @@
+!function(r, $) {
+  'use strict';
+  
+  $(function() {
+    $('a[href]').on('click', function(e) {
+      var el = this;
+      var $el = $(el);
+      var href = $el.attr('href');
+      var linkHost = href.match(/^https?:\/\/([^\/]+)/) && RegExp.$1;
+
+      // only tracking external links
+      if (linkHost === window.location.host) {
+        return true;
+      }
+
+      // get the name of the nearest parent element with a selfserve-* css class
+      // so the sales team can tell which instance of the link it is
+      var parentClass = $el.closest('[class^=selfserve]').attr('class');
+      var newTab = !!(el.target && el.target === '_blank');
+      var callback = newTab ? undefined : function() {
+        window.location.href = el.href;
+      };
+
+      r.analytics.fireGAEvent(
+        'advertising',
+        'external-link',
+        _.compact([parentClass, href]).join(':'),
+        undefined,
+        undefined,
+        callback);
+
+      return newTab;
+    });
+  });
+}(r, jQuery);

--- a/reddit_about/templates/advertising.html
+++ b/reddit_about/templates/advertising.html
@@ -54,7 +54,7 @@ from r2.lib.filters import safemarkdown
             <div class="col-4">
               <a href="${thing.create_ad_url}" class="create-ad-button primary-button button">${_("create an ad")}</a>
               <small>${_("budget larger than $30k?")}<br>
-              <a href="http://bit.ly/redditadvertising">${_("contact our sales team")}</a></small>
+              <a href="https://redditadvertising.typeform.com/to/OiZLa5">${_("contact our sales team")}</a></small>
             </div>
           </div>
         </div>

--- a/reddit_about/templates/advertising.html
+++ b/reddit_about/templates/advertising.html
@@ -54,7 +54,7 @@ from r2.lib.filters import safemarkdown
             <div class="col-4">
               <a href="${thing.create_ad_url}" class="create-ad-button primary-button button">${_("create an ad")}</a>
               <small>${_("budget larger than $30k?")}<br>
-              <a href="mailto:advertising@reddit.com?subject=campaign%20inquiry">${_("contact our sales team")}</a></small>
+              <a href="http://bit.ly/redditadvertising">${_("contact our sales team")}</a></small>
             </div>
           </div>
         </div>

--- a/reddit_about/templates/advertisingpage.html
+++ b/reddit_about/templates/advertisingpage.html
@@ -5,3 +5,9 @@
   ${parent.stylesheet()}
   ${less_stylesheet('selfserve.less')}
 </%def>
+
+<%def name="javascript_bottom()">
+  ${parent.javascript_bottom()}
+  <% from r2.lib import js %>
+  ${unsafe(js.use('advertising'))}
+</%def>


### PR DESCRIPTION
:eyeglasses: @madbook 

it seemed slightly less hacky just to treat all external links the same, this way we don't have to muck with the selector if we use a different form provider or something.  (are we allowed to do this?)  I also had to change the label to be `parentClass:href` due to GAs value needing to be an int.

**NOTE**: This PR relies on https://github.com/reddit/reddit-public/pull/3162
