### PR TITLE
Stop sampling logged in visitors by day

### DIFF
--- a/reddit_about/templates/about.html
+++ b/reddit_about/templates/about.html
@@ -97,7 +97,7 @@
   </div>
   <div class="line yesterday">
     ${stat('subreddits_active_yesterday', _('**yesterday**, reddit powered %(value)s active communities'), _('communities with at least 5 posts or comments yesterday'))}
-    ${stat('redditors_visited_yesterday', _('consisting of over %(value)s logged in redditors (est.)'), _('logged-in redditors yesterday'))}
+    ${stat('redditors_visited_yesterday', _('consisting of over %(value)s logged in redditors'), _('logged-in redditors yesterday'))}
     ${stat('vote_count_yesterday', _('casting over %(value)s votes'))}
   </div>
 </div>

--- a/reddit_about/templates/about.html
+++ b/reddit_about/templates/about.html
@@ -97,7 +97,7 @@
   </div>
   <div class="line yesterday">
     ${stat('subreddits_active_yesterday', _('**yesterday**, reddit powered %(value)s active communities'), _('communities with at least 5 posts or comments yesterday'))}
-    ${stat('redditors_visited_yesterday', _('consisting of over %(value)s logged in redditors'), _('logged-in redditors yesterday'))}
+    ${stat('redditors_visited_yesterday', _('consisting of over %(value)s logged in redditors (est.)'), _('logged-in redditors yesterday'))}
     ${stat('vote_count_yesterday', _('casting over %(value)s votes'))}
   </div>
 </div>

--- a/scripts/generate_stats.py
+++ b/scripts/generate_stats.py
@@ -75,7 +75,7 @@ def ga_stats(config, ranges):
 
     # We currently sample google analytics sessions, so we need to
     # multiply to determine the true visitor count. e.g. '50' for 50%.
-    SAMPLE_MULTIPLIER = 100 / int(g.googleanalytics_sample_rate)
+    SAMPLE_MULTIPLIER = 100 / float(g.googleanalytics_sample_rate)
 
     from apiclient.discovery import build
     from oauth2client.file import Storage
@@ -120,7 +120,7 @@ def ga_stats(config, ranges):
     ).execute()
 
     visitors = int(day_loggedin_stats['totalsForAllResults']['ga:visitors'])
-    stats['redditors_visited_yesterday'] = visitors * SAMPLE_MULTIPLIER
+    stats['redditors_visited_yesterday'] = int(visitors * SAMPLE_MULTIPLIER)
     return stats
 
 

--- a/scripts/generate_stats.py
+++ b/scripts/generate_stats.py
@@ -73,6 +73,10 @@ def traffic_stats(config, ranges):
 def ga_stats(config, ranges):
     stats = {}
 
+    # We currently sample google analytics sessions, so we need to
+    # multiply to determine the true visitor count. e.g. '50' for 50%.
+    SAMPLE_MULTIPLIER = 100 / int(g.googleanalytics_sample_rate)
+
     from apiclient.discovery import build
     from oauth2client.file import Storage
     from oauth2client.client import OAuth2WebServerFlow
@@ -114,7 +118,9 @@ def ga_stats(config, ranges):
         metrics='ga:visitors',
         filters='ga:customVarValue3=@loggedin'
     ).execute()
-    stats['redditors_visited_yesterday'] = int(day_loggedin_stats['totalsForAllResults']['ga:visitors'])
+
+    visitors = int(day_loggedin_stats['totalsForAllResults']['ga:visitors'])
+    stats['redditors_visited_yesterday'] = visitors * SAMPLE_MULTIPLIER
     return stats
 
 


### PR DESCRIPTION
:eyeglasses: @bsimpson63 

Internal ticket WEB-297.

We sample google analytics, but we don't unsample our visitor count from GA on the about page. This scales our number based on our sample rate.
