### PR TITLE
Remove about menu

### DIFF
--- a/reddit_about/__init__.py
+++ b/reddit_about/__init__.py
@@ -47,9 +47,8 @@ class About(Plugin):
 
     def add_routes(self, mc):
         # handle wildcard after /about/:action/ for postcard pushState URLs.
-        for route in ('/about/:action', '/about/:action/*etc'):
-            mc(route, controller='about', conditions={'function':not_in_sr},
-               requirements={'action':'team|postcards|alien|values'})
+        for route in ('/about/postcards', '/about/postcards/*etc'):
+            mc(route, controller='about', conditions={'function':not_in_sr})
         mc('/ad_inq', controller='redirect', action='redirect',
             dest='/advertising')
         mc('/advertising', controller='about', action='advertising', 

--- a/reddit_about/pages.py
+++ b/reddit_about/pages.py
@@ -22,16 +22,7 @@ class AboutPage(BoringPage):
         self.title_msg = title_msg
 
     def content(self):
-        about_buttons = [
-            NavButton(_('about reddit'), '/'),
-            NavButton(_('values'), '/values'),
-            NavButton(_('team'), '/team'),
-            NavButton(_('postcards'), '/postcards'),
-            NavButton(_('alien'), '/alien'),
-            #NavButton(_('guide'), '/guide')
-        ]
-        about_menu = NavMenu(about_buttons, type='tabmenu', base_path='/about/', css_class='about-menu')
-        return self.content_stack([AboutTitle(self.title_msg), about_menu, self._content])
+        return self.content_stack([AboutTitle(self.title_msg), self._content])
 
 
 class AboutTitle(Templated):


### PR DESCRIPTION
We're removing all links to the views on this page but the postcards
view. In order to keep the postcards page alive, we're going to
remove the menu from it.

This is hacky for now but for the sake of minimizing the already
uncomfortably large scope of the about pages, I'm not going to 
clean this up until after the they get deployed.

![screen shot 2016-05-16 at 4 17 27 pm](https://cloud.githubusercontent.com/assets/787203/15306690/b61754ea-1b81-11e6-9cfa-3e74179e13e5.png)

:eyeglasses: @MelissaCole 
