### PR TITLE
Delete references to deleted files

### DIFF
--- a/Makefile.plugin
+++ b/Makefile.plugin
@@ -1,1 +1,1 @@
-LESS_STYLESHEETS += about.less selfserve.less
+LESS_STYLESHEETS += about.less

--- a/reddit_about/__init__.py
+++ b/reddit_about/__init__.py
@@ -32,10 +32,6 @@ class About(Plugin):
             'about-postcards.js',
             prefix='about/',
         ),
-        'advertising': Module('advertising.js',
-            'advertising.js',
-            prefix='advertising/',
-        ),
     }
 
     def add_routes(self, mc):


### PR DESCRIPTION
selfserve.less and advertising.js were removed but still referenced
in places that broke the build process.

This has been breaking new staging installs.

👓 @spladug @mlburgos